### PR TITLE
fix(parsing/medium): encode url

### DIFF
--- a/src/parsing/medium.py
+++ b/src/parsing/medium.py
@@ -12,7 +12,7 @@ from telethon.tl.functions.messages import UploadMediaRequest
 from telethon.tl.types import InputMediaPhotoExternal, InputMediaDocumentExternal, \
     MessageMediaPhoto, MessageMediaDocument, InputFile, InputFileBig, InputMediaUploadedPhoto
 from telethon.errors import FloodWaitError, SlowModeWaitError, ServerError, BadRequestError
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 from .. import env, log, web, locks
 from .html_node import Code, Link, Br, Text, HtmlTree
@@ -950,7 +950,8 @@ def weserv_param_encode(param: str) -> str:
     hash_index = param.find('#')
     if hash_index != -1:
         param = param[:hash_index]  # remove fragment
-    return param.replace('&', '%26')  # & will mess up the query string, other characters are fine
+    param = quote(param)
+    return param
 
 
 def construct_weserv_url(url: str,


### PR DESCRIPTION
Here is the bad case:
https://businessreviewglobal-cdn.com/article_images/63dca28f3793f5679a70db21/images%2F_zh_CN_0_quipimage.jpeg%3Fstoreversion%3De669586fa54bda74c73eaec10dbe7574

wrong url:
https://wsrv.nl/?url=https://businessreviewglobal-cdn.com/article_images/63dca28f3793f5679a70db21/images%2F_zh_CN_0_quipimage.jpeg%3Fstoreversion%3De669586fa54bda74c73eaec10dbe7574

url after encode by `quote`:
https://wsrv.nl/?url=https%3A//businessreviewglobal-cdn.com/article_images/63dca28f3793f5679a70db21/images%252F_zh_CN_0_quipimage.jpeg%253Fstoreversion%253De669586fa54bda74c73eaec10dbe7574