### PR TITLE
build(deps): constrain aiosqlite for SQLite startup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,8 @@ matplotlib==3.9.4
 # db
 asyncpg==0.30.0
 tortoise-orm[accel]==0.25.1
+aiosqlite<0.22  # aiosqlite>=0.22 is incompatible with tortoise-orm==0.25.1 SQLite backend
+asyncclick<8.3; python_version < '3.11'  # asyncclick 8.3.0.3 misses its anyio dependency on Python 3.10
 aerich==0.8.1
 
 # network


### PR DESCRIPTION
## Changes

- Constrain `aiosqlite` to `<0.22`.
- `tortoise-orm==0.25.1` still calls `aiosqlite.Connection.start()` in its SQLite backend.
- `aiosqlite==0.22.x` no longer exposes that method, which breaks fresh SQLite startup during Aerich/Tortoise initialization.
- This keeps the existing Tortoise/Aerich stack unchanged while allowing pip to resolve a compatible `aiosqlite==0.21.x`.

